### PR TITLE
Update to Discord Rich Presence

### DIFF
--- a/DiscordRichPresence.cs
+++ b/DiscordRichPresence.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Collections.Generic;
 using DiscordRPC;
 using DiscordRPC.Logging;
 using DiscordRPC.Message;
@@ -15,8 +16,54 @@ namespace Spark
 		public static DiscordRpcClient discordClient;
 		public static DateTime initializationTime;
 		public static DateTime lastDiscordPresenceTime;
-		private static DateTime lobbyEntryTime;
-		private static bool inLobby;
+
+		// Generic timer variable to be used as Elapsed time on state that don't have an end time
+		private static DateTime initialStateTime;
+
+		// All the state the game can be in, used to properly set timers and monitor state changes
+		private enum GlobalGameState
+		{
+			Transitioning,
+			InGame,
+			InLobby,
+			Generic,
+			Disconnected
+		}
+
+
+		// Bool to detect if the status was changed
+		private static bool statusChanged;
+		// Setting last* variables to "Unknown" to force a status change when the Frame gets a valid status
+		private static string lastStatus = "Unknown";
+		private static string lastPausedState = "Unknown";
+
+		// Setting the state as Disconnected by default
+		private static GlobalGameState globalGameState = GlobalGameState.Disconnected;
+
+		// Used to easily convert game state from the API values to a pretty text for the Rich Presence
+		private static Dictionary<string, string> prettyGameStatus = new Dictionary<string, string>()
+		{
+			{"pre_match", "Pre-match" },
+			{"playing", "In Progress" },
+			{"score", "Score"},
+			{"round_start", "Round Start"},
+			{"pre_sudden_death", "Pre-Overtime"},
+			{"sudden_death", "Overtime"},
+			{"post_sudden_death", "Post-Match"},
+			{"round_over", "Post-Round"},
+			{"post_match", "Post-Match"},
+			{"Unknown", "Unknown"}
+		};
+
+		// Used to easily convert combat map name from the API values to a pretty text for the Rich Presence
+		private static Dictionary<string, string> prettyCombatMapName = new Dictionary<string, string>()
+		{
+			{"mpl_combat_dyson", "Dyson" },
+			{"mpl_combat_combustion", "Combustion" },
+			{"mpl_combat_fission", "Fission"},
+			{"mpl_combat_gauss", "Surge"}
+		};
+
 
 		private static Thread thread;
 
@@ -67,8 +114,6 @@ namespace Spark
 
 			discordClient.SetSubscription(EventType.Join | EventType.Spectate | EventType.JoinRequest);
 
-			lobbyEntryTime = DateTime.UtcNow;
-
 			// Connect to the RPC
 			discordClient.Initialize();
 		}
@@ -96,17 +141,65 @@ namespace Spark
 			});
 		}
 
+		// These 2 next function are mostly to avoid repeating code between Arena and Combat when building the details since it should be consistent between each game mode 
+
+		// Function that return a string containing if the match is Public or Private and set the secrets if private
+		private static string GetPrivateDetailsString(Frame frame, RichPresence rp)
+        {
+			if (frame.private_match)
+			{
+				rp.WithSecrets(new Secrets
+				{
+					JoinSecret = "spark://c/" + SecretKeys.Hash(frame.sessionid),
+					SpectateSecret = "spark://s/" + SecretKeys.Hash(frame.sessionid),
+				});
+				return "Private ";
+			}
+			else
+			{
+				return "Public ";
+			}
+		}
+
+		// Function that returns a string corresponding to if the user is spectating or not
+		private static string GetSpectatingDetailsString(Frame frame)
+        {
+			if (frame.teams[2].players.Find(p => p.name == frame.client_name) != null)
+			{
+				return "Spectating ";
+			}
+			else
+			{
+				return "Playing (" + frame.ClientTeamColor + ") ";
+			}
+		}
+
+		private static void RemoveRichPresence()
+        {
+			try
+			{
+				discordClient.SetPresence(null);
+				return;
+			}
+			catch (Exception)
+			{
+				LogRow(LogType.Error, "Discord RP client error when setting null presence.");
+				return;
+			}
+		}
+
 		public static void DisposeDiscord()
 		{
-			if (discordClient != null && !discordClient.IsDisposed)
+			if (discordClient != null && !discordClient.IsDisposed )
 				discordClient.Dispose();
 		}
 
 		public static void ProcessDiscordPresence(Frame frame)
 		{
-
+			// Check if the rich presence setting is enabled in Spark
 			if (SparkSettings.instance.discordRichPresence)
 			{
+				
 				if (discordClient == null || discordClient.IsDisposed)
 				{
 					//InitializeDiscord();
@@ -114,91 +207,275 @@ namespace Spark
 					return;
 				}
 
-				RichPresence rp = new RichPresence();
-
-				if (frame == null)
+				// Check if the frame is null and if Echo is closed
+				if (frame == null && Program.connectionState == Program.ConnectionState.NotConnected)
 				{
-					try
-					{
-						discordClient.SetPresence(null);
-						return;
-					}
-					catch (Exception)
-					{
-						LogRow(LogType.Error, "Discord RP client error when setting null presence.");
-						return;
-					}
+					// Setting match state variables back to default and the global state as Disconnected since Echo is no longer running
+					lastStatus = lastPausedState = "Unknown";
+					globalGameState = GlobalGameState.Disconnected;
+
+					// Removing rich presence since Echo is no longer running
+					RemoveRichPresence();
+					return;
 				}
 
+				// Initializing the variables needed to make the rich presence status
+				RichPresence rp = new RichPresence();
 				StringBuilder details = new StringBuilder();
-				switch (frame.map_name)
-				{
-					case "mpl_arena_a":
+				StringBuilder state = new StringBuilder();
+				
+				// Process the frame if it's not null
+				if (frame != null)
+                {
+					// The user has requested to disable rich presence while spectating, disabling rich presence accordingly
+					if (!string.IsNullOrEmpty(frame.teams[2].ToString()) && frame.teams[2].players.Find(p => p.name == frame.client_name) != null && SparkSettings.instance.discordRichPresenceSpectator)
 					{
-						if (frame.teams[2].players.Find(p => p.name == frame.client_name) != null)
-						{
-							details.Append("Spectating ");
-						}
-						else
-						{
-							details.Append("Playing ");
-						}
-
-						details.Append("Arena ");
-
-						if (frame.private_match)
-						{
-							details.Append("pvt.");
-
-							rp.WithSecrets(new Secrets
+						RemoveRichPresence();
+						return;
+					}
+					
+					// Check which map the user is in
+					switch (frame.map_name)
+					{
+						case "mpl_arena_a":
 							{
-								JoinSecret = "spark://c/" + SecretKeys.Hash(frame.sessionid),
-								SpectateSecret = "spark://s/" + SecretKeys.Hash(frame.sessionid),
-							});
-						}
-						else
-						{
-							details.Append("pub.");
-						}
+								// User is in a level, setting globalGameState to InGame
+								globalGameState = GlobalGameState.InGame;
 
-						rp.State = "Score: " + frame.orange_points + " - " + frame.blue_points;
-						rp.Timestamps = new Timestamps
-						{
-							End = frame.game_status == "post_match" ? DateTime.UtcNow : DateTime.UtcNow.AddSeconds(frame.game_clock)
-						};
+								// Bulding the details section
+
+								// Start with the game mode name
+								details.Append("Arena ");
+
+								// Check if the arena is Public or Private and set the status according to the result
+								details.Append(GetPrivateDetailsString(frame, rp));
+
+								// Adding the number of players per team in the team order as shown in game (Blue then Orange)
+								details.Append("(" + frame.teams[0].players.Count + " v " +frame.teams[1].players.Count + ")");
+
+								// Adding the score in the team order as shown in game (Blue then Orange)
+								details.Append(": " + frame.blue_points + " - " + frame.orange_points);
+
+								// Check if the user is spectating or playing the match and add set the proper status
+								state.Append(GetSpectatingDetailsString(frame));
+
+
+								// Building the State section
+
+								// Checking if the match was paused
+								if (frame.private_match && frame.pause.paused_state != "unpaused" && frame.pause.paused_state != "paused_requested")
+                                {
+									// Check if the match is not already paused
+									if (lastPausedState != frame.pause.paused_state)
+                                    {
+										// Set the lastPausedState to the current pause state since it just changed
+										lastPausedState = frame.pause.paused_state;
+
+										// Making sure to put the paused time based on the info from the game API so it shows accurate time if someone backfills a match while it's paused
+										initialStateTime = DateTime.UtcNow.AddSeconds(-frame.pause.paused_timer);
+									}
+
+									
+									// Set the status to the pause state and making the first letter uppercase so it looks prettier
+									state.Append(" - " + char.ToUpper(frame.pause.paused_state[0]) + frame.pause.paused_state.Substring(1));
+
+									rp.Timestamps = new Timestamps
+									{
+										Start = initialStateTime
+									};
+									 
+								}
+								else
+                                {
+									// If the frame return an empty or null game_status string, set it to the last knonwn status
+									// This is done only if the game is not already paused or unpausing as the API returns an empty string for the game_status when the match is paused or unpausing
+									if (String.IsNullOrEmpty(frame.game_status)) frame.game_status = lastStatus;
+
+
+									// Check if the status has changed and if it did, set laststatus to the current game status
+									if (statusChanged = lastStatus != frame.game_status) lastStatus = frame.game_status;
+
+
+									// If the user is in any pre-match state, set an elapsed timer instead of the remaining game time since it won't change until the match starts
+									if (frame.game_status == "pre_match" || frame.game_status == "pre_sudden_death")
+									{
+										// Check if the status has changed and set the initialStateTime to the current time if it did
+										if (statusChanged)
+										{
+											// Making sure the status is no longer changed to avoid resetting the timer
+											statusChanged = false;
+											initialStateTime = DateTime.UtcNow;
+										}
+										rp.Timestamps = new Timestamps
+										{
+											Start = initialStateTime
+										};
+									}
+									// User is in a game that is not paused or in any pre-match state, set the remaining time to the one given by the game_clock value
+									else
+									{
+										rp.Timestamps = new Timestamps
+										{
+											// If the game is in the post-match state, set the end time to now, otherwise set it based on the game_clock value
+											End = frame.game_status == "post_match"  ? DateTime.UtcNow : DateTime.UtcNow.AddSeconds(frame.game_clock)
+										};
+									}
+									// Put the game status at the end of the state
+									state.Append(" - " + prettyGameStatus[frame.game_status]);
+								}
+								break;
+							}
+						// Check if the user is in a Combat match
+						case "mpl_combat_dyson": case "mpl_combat_combustion": case "mpl_combat_fission": case "mpl_combat_gauss":
+                            {
+								// Setting up a generic timer for the elapsed time since the API doesn't return any time or match status reference in Combat
+								if (globalGameState != GlobalGameState.InGame)
+								{
+									// User is in a level, setting globalGameState to InGame
+									globalGameState = GlobalGameState.InGame;
+									initialStateTime = DateTime.UtcNow;
+								}
+								rp.Timestamps = new Timestamps
+								{
+									Start = initialStateTime
+								};
+
+
+								// Bulding the details section 
+
+								// Setting the map name
+								details.Append(prettyCombatMapName[frame.map_name] + " ");
+
+								//Check if the Combat is Public or Private and set the status according to the result
+								details.Append(GetPrivateDetailsString(frame, rp));
+
+								// Adding the number of players per team in the team order shown in game (Blue then Orange)
+								details.Append("(" + frame.teams[0].players.Count + " v " + frame.teams[1].players.Count + ")");
+
+
+
+								// Building the State section
+
+								// Check if the user is spectating or playing the match
+								state.Append(GetSpectatingDetailsString(frame));
+
+
+								// Todo : Add actual stats when the new API drops
+								break;
+							}
+						// User is not in a valid map, defaulting status to generic status
+						default:
+							// Setting game states back to default as the user is no longer considered in a game
+							lastStatus = lastPausedState = "Unknown";
+
+							// Setting the details to generic status message
+							//details.Append("Playing Echo VR");
+
+							// Use a generic timer of how long the user has been playing Echo
+							if (globalGameState != GlobalGameState.Generic)
+							{
+								globalGameState = GlobalGameState.Generic;
+								initialStateTime = DateTime.UtcNow;
+							}
+							rp.Timestamps = new Timestamps
+							{
+								Start = initialStateTime
+							};
+							break;
+					}
+
+					// Setting the state if it exists
+					if (!string.IsNullOrEmpty(state.ToString())) rp.State = state.ToString();
+
+
+					// Set the party info if the game state is valid
+					if(globalGameState != GlobalGameState.Generic)
+                    {
 						rp.WithParty(new Party
 						{
 							ID = frame.sessionid,
 							Size = frame.GetAllPlayers().Count,
 							Max = frame.private_match ? 15 : 8
 						});
-						break;
 					}
-					case "mpl_lobby_b2":
-					{
-						details.Append("in EchoVR Lobby");
+				}
+				else
+                {
+					// frame is null, set status based on ConnectionState
+					switch (Program.connectionState)
+                    {
+						// Looking at the connection state to determine if the user is in a Lobby as a workaround since /session is restricted in the lobby
+						case Program.ConnectionState.InLobby:
+                        {
+							//  Resetting the match status to default since the user is in a Lobby
+							lastStatus = lastPausedState = "Unknown";
 
-						// how long have we been in the lobby?
-						if (!inLobby)
-						{
-							inLobby = true;
-							lobbyEntryTime = DateTime.UtcNow;
-						}
-						rp.Timestamps = new Timestamps
-						{
-							Start = lobbyEntryTime
-						};
-						break;
+							// Set the status to only "in EchoVR Lobby" since the API doesn't give any informations in Lobbys
+							details.Append("in EchoVR Lobby");
+
+							// If the user just entered the Lobby, set initialStateTime to current time
+							if (globalGameState != GlobalGameState.InLobby)
+							{
+								// Properly set the state to InLobby to avoid the timer being resetted while the user is still in the Lobby
+								globalGameState = GlobalGameState.InLobby;
+								initialStateTime = DateTime.UtcNow;
+							}
+							rp.Timestamps = new Timestamps
+							{
+								Start = initialStateTime
+							};
+								break;
+                        }
+						// User is in a Transition
+						case Program.ConnectionState.Menu:
+                        {
+							// Ignore transition if using the generic status to preserve the elapsed time
+							if (globalGameState == GlobalGameState.Generic) return;
+
+							// Resetting the match status to default since the user is in a transition
+							lastStatus = lastPausedState = "Unknown";
+
+							// Set the status to just "In Transition" since the API doesn't give any information during a transition
+							details.Append("In Transition");
+
+							// If the user just entered the transition, set initialStateTime to current time and then set the status to Transitioning
+							if (globalGameState != GlobalGameState.Transitioning)
+							{
+								globalGameState = GlobalGameState.Transitioning;
+								initialStateTime = DateTime.UtcNow;
+							}
+							rp.Timestamps = new Timestamps
+							{
+								Start = initialStateTime
+							};
+							break;
+                        }
+						// Api is not enabled, setting a generic "Playing Echo VR" status
+						case Program.ConnectionState.NoAPI:
+                        {
+							// API is no longer enabled, setting status to default values
+							lastStatus = lastPausedState = "Unknown";
+
+							// Use a generic timer of how long the user has been playing Echo
+							if (globalGameState != GlobalGameState.Generic)
+							{
+								globalGameState = GlobalGameState.Generic;
+								initialStateTime = DateTime.UtcNow;
+							}
+							rp.Timestamps = new Timestamps
+							{
+								Start = initialStateTime
+							};
+							break;
+                        }
 					}
-					// if (frame.map_name == "whatever combat is")
-					default:
-						details.Append("Playing Combat");
-						break;
 				}
 
-				rp.Details = details.ToString();
+				// Adding the details and assets to the RichPresence
+				if(!String.IsNullOrEmpty(details.ToString())) rp.Details = details.ToString();
 				rp.Assets = new Assets
-				{
+				{ 
+					//ToDo: Posibly make or find a Combat icon?
 					LargeImageKey = "echo_arena_store_icon",
 					LargeImageText = SparkSettings.instance.discordRichPresenceServerLocation && 
 					                 !string.IsNullOrEmpty(Program.CurrentRound?.serverLocation) 
@@ -206,7 +483,7 @@ namespace Spark
 						: "Rich presence from Spark"
 				};
 
-
+				// Setting the Rich presence
 				discordClient.SetPresence(rp);
 			}
 			else

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Spark.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -971,6 +971,15 @@ namespace Spark.Properties {
         public static string Discord_Rich_Presence {
             get {
                 return ResourceManager.GetString("Discord Rich Presence", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable Discord Rich Presence when spectating matches.
+        /// </summary>
+        public static string Discord_Rich_Presence_Spectator {
+            get {
+                return ResourceManager.GetString("Discord Rich Presence Spectator", resourceCulture);
             }
         }
         

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="(Requires Restart)" xml:space="preserve">
     <value>(Requires Restart)</value>
@@ -138,7 +138,7 @@
   <data name="Autorestart EchoVR into autospectator" xml:space="preserve">
     <value>Autorestart EchoVR into Spectatorstream</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="baseline_replay_white_24px" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\img\baseline_replay_white_24px.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
@@ -591,7 +591,8 @@ Riftでは、Windowsのデフォルトのサウンド出力をRiftのヘッド�
     <value>Tube Exit Speed (self)</value>
   </data>
   <data name=", or join the" xml:space="preserve">
-    <value>, or join the</value><comment>Full sentence is: For help using Spark, check out the Echopedia page, or join the Ignite Discord Server and ask questions in the #spark-support channel.</comment>
+    <value>, or join the</value>
+    <comment>Full sentence is: For help using Spark, check out the Echopedia page, or join the Ignite Discord Server and ask questions in the #spark-support channel.</comment>
   </data>
   <data name="and ask questions in the #ignitebot-support channel." xml:space="preserve">
     <value>and ask questions in the #spark-support channel.</value>
@@ -603,7 +604,8 @@ Riftでは、Windowsのデフォルトのサウンド出力をRiftのヘッド�
     <value>Echopedia page</value>
   </data>
   <data name="for_help_check_out" xml:space="preserve">
-    <value>For help using Spark, check out the</value><comment>Full sentence is: For help using Spark, check out the Echopedia page, or join the Ignite Discord Server and ask questions in the #spark-support channel.</comment>
+    <value>For help using Spark, check out the</value>
+    <comment>Full sentence is: For help using Spark, check out the Echopedia page, or join the Ignite Discord Server and ask questions in the #spark-support channel.</comment>
   </data>
   <data name="Ignite Discord Server" xml:space="preserve">
     <value>Ignite Discord Server</value>
@@ -653,7 +655,8 @@ CLOSE ECHOVR BEFORE PRESSING OK!</value>
     <value>Stop Spectating Me</value>
   </data>
   <data name="Voice" xml:space="preserve">
-    <value>Voice</value><comment>For what kind of TTS voice to use</comment>
+    <value>Voice</value>
+    <comment>For what kind of TTS voice to use</comment>
   </data>
   <data name="orange" xml:space="preserve">
     <value>orange</value>
@@ -1681,5 +1684,8 @@ Old Replay folder: 'C:\Users\[USER]\Documents\IgniteBot\'
   </data>
   <data name="Clear TTS Cache" xml:space="preserve">
     <value>Clear TTS Cache</value>
+  </data>
+  <data name="Discord Rich Presence Spectator" xml:space="preserve">
+    <value>Disable Discord Rich Presence when spectating matches</value>
   </data>
 </root>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Spark.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -1424,6 +1424,18 @@ namespace Spark.Properties {
             }
             set {
                 this["obsSaveReplayScene"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool discordRichPresenceSpectator {
+            get {
+                return ((bool)(this["discordRichPresenceSpectator"]));
+            }
+            set {
+                this["discordRichPresenceSpectator"] = value;
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -353,5 +353,8 @@
     <Setting Name="obsSaveReplayScene" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="discordRichPresenceSpectator" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SparkSettings.cs
+++ b/SparkSettings.cs
@@ -20,6 +20,7 @@ namespace Spark
 		public bool showDatabaseLog { get; set; } = false;
 		public bool discordRichPresence { get; set; } = true;
 		public bool discordRichPresenceServerLocation { get; set; } = false;
+		public bool discordRichPresenceSpectator { get; set; } = false;
 		public bool logToServer { get; set; } = false;
 		public string echoVRPath { get; set; } = "";
 		public string echoVRIP { get; set; } = "127.0.0.1";

--- a/Windows/Settings/UnifiedSettingsWindow.xaml
+++ b/Windows/Settings/UnifiedSettingsWindow.xaml
@@ -144,6 +144,9 @@
 						<CheckBox x:Name="discordRichPresenceServerLocationCheckbox" Content="{x:Static p:Resources.Show_Server_Location_in_Discord_RP_status}"
 									  IsChecked="{l:SettingBinding discordRichPresenceServerLocation}" HorizontalAlignment="Left"
 									  VerticalAlignment="Stretch" Margin="10,4,10,4" />
+                        <CheckBox x:Name="discordRichPresenceSpectatorCheckbox" Content="{x:Static p:Resources.Discord_Rich_Presence_Spectator}"
+									  IsChecked="{l:SettingBinding discordRichPresenceSpectator}" HorizontalAlignment="Left"
+									  VerticalAlignment="Stretch" Margin="10,4,10,4" />
 						
 						
 						


### PR DESCRIPTION
I added a couple of improvements to the Discord Rich Presence, notably :
- Fixed Lobby Rich Presence
- Added a "Transition" Rich Presence status for when the user is in a loading screen
- Added "Generic" Rich Presence for when the API is not enabled in Echo or if the user is in an unknown level
- Added the number of player per teams in the details
- Added the team the user is playing in the state
- Added a status for when a Private Arena is paused in the state
- Added the map the user is playing in Combat in the details
- Added an option in the settings to disable Rich Presence when spectating a match


Here's some screenshots of how it looks with the changes :
![Screenshot_20220706_042734](https://user-images.githubusercontent.com/6498070/177506063-303467c2-a9f4-431c-b620-af5c9f1a4bb6.png)
![Screenshot_20220706_042513](https://user-images.githubusercontent.com/6498070/177506066-cc496fe4-0c8c-4a61-8597-2887f0ce442d.png)
![Screenshot_20220706_042357](https://user-images.githubusercontent.com/6498070/177506068-5a2922cc-8587-4842-8c3c-dbeb966d0fa7.png)
![Screenshot_20220706_042220](https://user-images.githubusercontent.com/6498070/177506069-a5e8f397-9f07-42fa-9c27-87de623dc1f7.png)
![Screenshot_20220706_042201](https://user-images.githubusercontent.com/6498070/177506073-b29c1b53-eec2-4e88-a26d-61d67b6ac483.png)

Let me know if any changes are needed and I'll be happy to do them! 
I also plan on adding more Combat stats later when the new patch with the Combat API changes will be available.
