### PR TITLE
Don't update rich presence if frame.GetPlayer == null

### DIFF
--- a/DiscordRichPresence.cs
+++ b/DiscordRichPresence.cs
@@ -227,6 +227,13 @@ namespace Spark
 				// Process the frame if it's not null
 				if (frame != null)
 				{
+					// If player is spectating as a moderator, don't update rich presence.
+                    			if (frame.GetPlayer(frame.client_name) == null)
+                    			{
+                        			RemoveRichPresence();
+                        			return;
+                    			}
+					
 					// The user has requested to disable rich presence while spectating, disabling rich presence accordingly
 					if (!string.IsNullOrEmpty(frame.teams[2].ToString()) && frame.teams[2].players.Find(p => p.name == frame.client_name) != null && SparkSettings.instance.discordRichPresenceSpectator)
 					{


### PR DESCRIPTION
The case when a user is spectating a match while using the -moderator launch argument.
Prevents spark from crashing trying to update rich presence when this is the case.
